### PR TITLE
"Temporary?" Fix for undefined method `html_escape'

### DIFF
--- a/lib/green_monkey/ext/action_view.rb
+++ b/lib/green_monkey/ext/action_view.rb
@@ -11,7 +11,7 @@ module ActionView::Helpers::TagHelper
           attrs << key.to_s if value
         elsif !value.nil?
           final_value = value.is_a?(Array) ? value.join(" ") : value
-          final_value = html_escape(final_value) if escape
+          final_value = ERB::Util.html_escape(final_value) if escape
           attrs << %(#{key}="#{final_value}")
         end
       end


### PR DESCRIPTION
Not sure what's causing the missing method html_escape, but for now I switched the call to:

ERB::Util.html_escape and it fixes it.
