### PR TITLE
Fix init issue

### DIFF
--- a/lib/green_monkey/railtie.rb
+++ b/lib/green_monkey/railtie.rb
@@ -2,14 +2,16 @@
 
 module GreenMonkey
   class Railtie < Rails::Railtie
-    initializer "load extentions and patches" do
+    initializer 'green_monkey.init', :before=> :load_config_initializers do
       require "green_monkey/ext/active_model"
-      ActiveModel::Dirty.send :include, GreenMonkey::ModelHelpers
+      ActiveSupport.on_load(:active_record) do
+        include(GreenMonkey::ModelHelpers)
+      end
       
       require 'green_monkey/ext/view_helper'
       ActionView::Base.send :include, GreenMonkey::ViewHelper
         
-      require "green_monkey/ext/action_view"
+      # require "green_monkey/ext/action_view"
       require "green_monkey/ext/haml"
       require "green_monkey/ext/mida"
     end


### PR DESCRIPTION
Fixes issue #5

It also removes weird `hack replaces itemscope="itemscope" => itemscope` because html5 allows 

```
<div itemscope itemtype ="http://schema.org/Movie">
```

 as shown here http://schema.org/docs/gs.html#microdata_itemscope_itemtype

HTML5 is the default for Rails > 3.1and that is how HAML behaves.
